### PR TITLE
Add missing "header" to PROGRAM OUTPUT section on the template.

### DIFF
--- a/lib/CPAN/Testers/Common/Client.pm
+++ b/lib/CPAN/Testers/Common/Client.pm
@@ -52,6 +52,8 @@ sub _init {
                      : 'none provided'
                    );
 
+    $self->command( $params{command} ) if exists $params{command};
+
     if ( $params{prereqs} ) {
         $self->{_meta}{prereqs} = $params{prereqs}
     }
@@ -105,6 +107,11 @@ sub grade {
     return $self->{_grade};
 }
 
+sub command {
+    my ($self, $command) = @_;
+    $self->{_command} = $command if $command;
+    return $self->{_command} || '';
+}
 
 #====================================
 #  PUBLIC METHODS
@@ -564,6 +571,7 @@ HERE
         via                => $self->via,
         grade              => $self->grade,
         comment            => $self->comments,
+        command            => $self->command,
         test_log           => $metabase_data->{TestOutput}{test} || '',
         prereq_pm          => _format_prereq_report( $metabase_data->{Prereqs} ),
         env_vars           => _format_vars_report( $metabase_data->{TestEnvironment}{environment_vars} ),
@@ -602,6 +610,8 @@ $data{comment}
 ------------------------------
 PROGRAM OUTPUT
 ------------------------------
+
+Output from '$data{command}':
 
 $data{test_log}
 ------------------------------
@@ -711,6 +721,8 @@ Although the recommended is to construct your object passing as much information
 =item * grade - 'pass', 'fail', 'na', 'unknown'. B<Required>.
 
 =item * via - sender module (CPAN::Reporter, CPANPLUS, etc). Defaults to "Your friendly CPAN Testers client"
+
+=item * command - the command used to test the distribution.
 
 =back
 

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -22,6 +22,8 @@ is $client->distname, $dist, 'got proper distname';
 
 is $client->grade, $grade, 'got the proper grade';
 
+is $client->command, '', 'got the proper command';
+
 is(
     $client->via,
     'your friendly CPAN Testers client version ' . $CPAN::Testers::Common::Client::VERSION,
@@ -79,6 +81,7 @@ ok $client = CPAN::Testers::Common::Client->new(
     grade    => $grade,
     via      => 'AwesomeClient 2.0 pre-beta',
     comments => 'oh, noes!',
+    command  => '/compile/and/test/me/please',
 
     configure_output => 'TUPTUO ERUGIFNOC',
     build_output     => 'TUPTUO DLIUB',
@@ -102,6 +105,7 @@ like $email, qr/Test::More/, 'runtime prereq';
 like $email, qr/Test::Most/, 'build prereq 1';
 like $email, qr/Test::LongString/, 'build_prereq 2';
 like $email, qr/Test::Builder/, 'configure_prereq';
+like $email, qr|Output from '/compile/and/test/me/please':|, 'command';
 
 
 done_testing;


### PR DESCRIPTION
Hi Garu,

The template that Common::Client is generating is missing the line
"Output from 'something like make test':"
in the beginning of the PROGRAM OUTPUT.

I think this is necessary in the work of using Common::Client inside CPAN::Reporter, to maintain (at least for now) the same template begin generated and keep the tests from CPAN::Reporter passing :-)

Another way to solve this would be to Common::Client users pass this line concatenated to the test_output parameter, but I'm not sure this is right, basically for 2 reasons:
(1) It's not actually part of the test output.
(2) All other sections have some kind of line/header on beginning hard coded =P

So, if this solution is ok for you, please merge it :-)

PS: And yes, I'm writing all this while I'm almost at your side, lol
