### PR TITLE
Allow spaces in metabase config file name

### DIFF
--- a/lib/CPAN/Testers/Common/Client/Config.pm
+++ b/lib/CPAN/Testers/Common/Client/Config.pm
@@ -632,6 +632,7 @@ sub _validate_transport {
     my $transport = '';
     my $transport_args = '';
 
+    my $id_file;
     if ( $option =~ /^(\w+(?:::\w+)*)\s*(\S.*)$/ ) {
         ($transport, $transport_args) = ($1, $2);
         my $full_class = "Test::Reporter::Transport::$transport";
@@ -665,7 +666,7 @@ sub _validate_transport {
             return;
         }
 
-        my $id_file = $self->_normalize_id_file($1);
+        $id_file = $self->_normalize_id_file($1);
 
         # Offer to create if it doesn't exist
         if ( ! -e $id_file )  {
@@ -701,11 +702,14 @@ END_ID_FILE
 
         # when we store the transport args internally,
         # we should use the normalized id_file.
-        $transport_args =~ s/(\bid_file\s+)(\S.+?)\s*$/$1$id_file/;
+        $transport_args =~ s/(\bid_file\s+)(\S.+?)\s*$//;
+        warn $id_file;
+        warn $transport_args;
     } # end Metabase
 
     $self->{_transport_name} = $transport;
     $self->{_transport_args} = [ split( /\s+/ => $transport_args ) ];
+    push @{ $self->{_transport_args} }, ('id_file', $id_file);
     return 1;
 }
 


### PR DESCRIPTION
(Maybe not the prettiest fix, but it's a fix). cpanm-reporter died because my path had a space. This can be pretty common since the .cpanreporter folder is located in a directory named after the user (mine is 'Nate Glenn').