### PR TITLE
Patches for excessive "Use of uninitialized value " due to Modulino fatalizing silently.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+---
+language: perl

--- a/lib/CPAN/Testers/Common/Client.pm
+++ b/lib/CPAN/Testers/Common/Client.pm
@@ -508,7 +508,7 @@ sub _version_finder {
     print {$fh} map { "$_ $prereqs{$_}\n" } keys %prereqs;
     close $fh;
 
-    my $prereq_result = capture { system( $perl, $version_finder, '<', $prereq_input ) };
+    my $prereq_result = capture { system( $perl, $version_finder, $prereq_input ) };
     unlink $prereq_input;
 
     my %result;

--- a/lib/CPAN/Testers/Common/Client.pm
+++ b/lib/CPAN/Testers/Common/Client.pm
@@ -514,6 +514,9 @@ sub _version_finder {
     if ( length $error ) {
       print STDERR $error;
     }
+    if ( not length $prereq_result) {
+      warn "Got no output from CPAN::Testers::Common::Client::Prereq::Check";
+    }
     my %result;
     for my $line ( split "\n", $prereq_result ) {
         next unless length $line;

--- a/lib/CPAN/Testers/Common/Client.pm
+++ b/lib/CPAN/Testers/Common/Client.pm
@@ -508,9 +508,12 @@ sub _version_finder {
     print {$fh} map { "$_ $prereqs{$_}\n" } keys %prereqs;
     close $fh;
 
-    my $prereq_result = capture { system( $perl, $version_finder, $prereq_input ) };
+    my ( $prereq_result, $error, $exit ) = capture { system( $perl, $version_finder, $prereq_input ) };
     unlink $prereq_input;
 
+    if ( length $error ) {
+      print STDERR $error;
+    }
     my %result;
     for my $line ( split "\n", $prereq_result ) {
         next unless length $line;

--- a/lib/CPAN/Testers/Common/Client.pm
+++ b/lib/CPAN/Testers/Common/Client.pm
@@ -281,11 +281,13 @@ sub _format_vars_report {
     return $report;
 }
 
+sub _fix_unknown { defined $_[0] ? $_[0] : 'unknown' }
+
 sub _format_toolchain_report {
     my $installed = shift;
     my $mod_width = _max_length( keys %$installed );
     my $ver_width = _max_length(
-        map { $installed->{$_} } keys %$installed
+        map { _fix_unknown( $installed->{$_} ) } keys %$installed
     );
 
     my $format = "    \%-${mod_width}s \%-${ver_width}s\n";
@@ -296,7 +298,7 @@ sub _format_toolchain_report {
 
     for my $var ( sort keys %$installed ) {
         $report .= sprintf("    \%-${mod_width}s \%-${ver_width}s\n",
-                            $var, $installed->{$var} );
+                            $var, _fix_unknown($installed->{$var}) );
     }
 
     return $report;
@@ -330,7 +332,7 @@ sub _format_prereq_report {
         foreach my $module ( keys %$requires ) {
             my $name_length = length $module;
             my $need_length = length $requires->{$module};
-            my $have_length = length $have{$section}{$module};
+            my $have_length = length _fix_unknown( $have{$section}{$module} );
             $name_width = $name_length if $name_length > $name_width;
             $need_width = $need_length if $need_length > $need_width;
             $have_width = $have_length if $have_length > $have_width;
@@ -355,7 +357,7 @@ sub _format_prereq_report {
 
       foreach my $module ( sort {lc $a cmp lc $b} keys %$requires ) {
         my $need = $requires->{$module};
-        my $have = $have{$section}{$module};
+        my $have = _fix_unknown( $have{$section}{$module} );
         my $bad = $prereq_met{$section}{$module} ? " " : "!";
         $report .= sprintf( $format_str, $bad, $module, $need, $have);
       }

--- a/t/03-undef-prereq-report.t
+++ b/t/03-undef-prereq-report.t
@@ -1,0 +1,78 @@
+
+use strict;
+use warnings;
+
+use Test::More;
+
+# FILENAME: 03-undef-prereq-report.t
+# CREATED: 03/23/15 20:25:56 by Kent Fredric (kentnl) <kentfredric@gmail.com>
+# ABSTRACT: Test undef in prereq reports
+
+sub nowarn {
+    my ( $reason, $code ) = @_;
+    my @warns;
+    {
+        local $SIG{__WARN__} = sub { push @warns, $_[0] };
+        $code->();
+    };
+    return 1 if ok( !scalar @warns, $reason );
+    diag explain \@warns;
+    return;
+}
+
+use CPAN::Testers::Common::Client;
+
+my $rreqs = <<"EOF";
+version 0
+CPAN 0
+ExtUtils::Command 0
+ExtUtils::ParseXS 0
+File::Spec 0
+YAML 0
+YAML::Syck 0
+EOF
+
+my $prereqs = { runtime => { requires => { split /\s+/sm, $rreqs } } };
+
+{
+    my $report;
+    my $ok = nowarn "No warnings emitted from real report generation" => sub {
+        $report =
+          CPAN::Testers::Common::Client::_format_prereq_report($prereqs);
+    };
+    $ok ? note $report : diag $report;
+}
+
+{
+    my $report;
+    my $ok = nowarn "No warnings emitted in bad report generation" => sub {
+        no warnings 'redefine';
+
+        # Emulate a broken finder that returns an empty hash due
+        # to silently SEGV/LD Sym fail.
+        local *CPAN::Testers::Common::Client::_version_finder =
+          sub { return {} };
+
+        $report =
+          CPAN::Testers::Common::Client::_format_prereq_report($prereqs);
+    };
+    $ok ? note $report : diag $report;
+}
+
+{
+    my $report;
+    my $installed = {
+        good    => 1,
+        another => 2,
+        bad     => undef,
+        zero    => 0,
+    };
+    my $ok = nowarn "No warnings emitted by toolchain report" => sub {
+        $report =
+          CPAN::Testers::Common::Client::_format_toolchain_report($installed);
+    };
+    $ok ? note $report : diag $report;
+}
+
+done_testing;
+


### PR DESCRIPTION
Due to https://rt.perl.org/Ticket/Display.html?id=124151, there's some really annoying behaviour that happens when anyone does `require ExtUtils::ParseXS` while `CWD` happens to have "lib/<tree of perl libraries and `.so`s>".

This results in the modulino silently failing and _version_finder returning an empty hash, and metabase returning lots of undef values.

This causes a lot of warnings:
```
Use of uninitialized value in numeric gt (>) at /home/kent/perl5/perlbrew/perls/5.21.10/lib/site_perl/5.21.10/CPAN/Testers/Common/Client.pm line 454.
Use of uninitialized value in sprintf at /home/kent/perl5/perlbrew/perls/5.21.10/lib/site_perl/5.21.10/CPAN/Testers/Common/Client.pm line 299
Use of uninitialized value $max in numeric gt (>) at /home/kent/perl5/perlbrew/perls/5.21.10/lib/site_perl/5.21.10/CPAN/Testers/Common/Client.pm line 454
Use of uninitialized value $ver_width in concatenation (.) or string at /home/kent/perl5/perlbrew/perls/5.21.10/lib/site_perl/5.21.10/CPAN/Testers/Common/Client.pm line 291.
se of uninitialized value $ver_width in repeat (x) at /home/kent/perl5/perlbrew/perls/5.21.10/lib/site_perl/5.21.10/CPAN/Testers/Common/Client.pm line 295.
Use of uninitialized value $ver_width in concatenation (.) or string at /home/kent/perl5/perlbrew/perls/5.21.10/lib/site_perl/5.21.10/CPAN/Testers/Common/Client.pm line 299.
Use of uninitialized value in sprintf at /home/kent/perl5/perlbrew/perls/5.21.10/lib/site_perl/5.21.10/CPAN/Testers/Common/Client.pm line 299.
```

And produces blank fields in the report.

So, in response, this patch series:

- Captures any errors emitted by the modulino and printing them, to expose where the errors are happening.  (presently it is silent)
- Warns if the modulino prints nothing to stdout ( presently, it just returns an empty hash silently )
- Wraps any undef values in report generation so they're rendered as the text "unknown".
- Additionally, stops attempting to pass the literal file "<" as an argument to the modulino, because that presently creates its own error/warning.
