### PR TITLE
fix "Nested quantifiers in regex" error on perl 5.8.x

### DIFF
--- a/lib/CPAN/Testers/Common/Client/Config.pm
+++ b/lib/CPAN/Testers/Common/Client/Config.pm
@@ -723,7 +723,7 @@ END_ID_FILE
 sub _parse_transport_args {
     my ($transport_args) = @_;
     my @args;
-    while ($transport_args =~ /\s*((?:[^'"\s]\S*)|(["'])(?:\\?+.)*?\2)/g) {
+    while ($transport_args =~ /\s*((?:[^'"\s]\S*)|(["'])(?:(?>\\?).)*?\2)/g) {
         my $arg = $1;
         if ($2) {
             $arg =~ s/\A(['"])(.+)\1\z/$2/;


### PR DESCRIPTION
closes issue #11 

All tests pass, but please confirm that I did not change the intention of the regex!
