### PR TITLE
CORE::* is only supported in 5.16+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ pm_to_blib*
 cover_db
 pod2htm*.tmp
 CPAN-Testers-Common-Client-*
+MYMETA.*

--- a/lib/CPAN/Testers/Common/Client/Config.pm
+++ b/lib/CPAN/Testers/Common/Client/Config.pm
@@ -18,7 +18,7 @@ sub new {
         _config => {},
     }, $class;
 
-    my $warn = exists $args{'warn'} ? $args{'warn'} : \&CORE::warn;
+    my $warn = exists $args{'warn'} ? $args{'warn'} : sub { warn @_ };
     $self->_set_mywarn( $warn )
         or Carp::croak q(the 'warn' parameter must be a coderef);
 

--- a/t/03-history.t
+++ b/t/03-history.t
@@ -1,7 +1,8 @@
 use strict;
 use warnings;
 use Test::More; # tests => 3;
-use t::MockHomeDir;
+use lib 't';
+use MockHomeDir;
 use Capture::Tiny qw( capture   );
 use File::Path    qw( make_path );
 

--- a/t/MockHomeDir.pm
+++ b/t/MockHomeDir.pm
@@ -1,4 +1,4 @@
-package t::MockHomeDir;
+package MockHomeDir;
 use strict;
 BEGIN{ if (not $] < 5.006) { require warnings; warnings->import } }
 use File::Spec;


### PR DESCRIPTION
Fixes errors like:

```
Undefined subroutine &CORE::warn called at /Volumes/amaretto/Users/ether/.perlbrew/libs/10.1@std/lib/perl5/CPAN/Testers/Common/Client/Config.pm line 87.
```

(and closes #13)